### PR TITLE
add esmf summary parser

### DIFF
--- a/src/access/profiling/__init__.py
+++ b/src/access/profiling/__init__.py
@@ -10,6 +10,7 @@ with suppress(PackageNotFoundError):
     __version__ = version("access-profiling")
 
 from access.profiling.cice5_parser import CICE5ProfilingParser
+from access.profiling.esmf_parser import ESMFSummaryProfilingParser
 from access.profiling.fms_parser import FMSProfilingParser
 from access.profiling.parser import ProfilingParser
 from access.profiling.payujson_parser import PayuJSONProfilingParser
@@ -21,4 +22,5 @@ __all__ = [
     "UMProfilingParser",
     "CICE5ProfilingParser",
     "PayuJSONProfilingParser",
+    "ESMFSummaryProfilingParser",
 ]

--- a/src/access/profiling/esmf_parser.py
+++ b/src/access/profiling/esmf_parser.py
@@ -1,0 +1,178 @@
+# Copyright 2025 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Parser for ESMF profiling text summary data, such as output by nuopc.
+The data to be parsed is written in the following form:
+
+Region                                       PETs   PEs    Count    Mean (s)    Min (s)     Min PET Max (s)     Max PET
+  [ESMF]                                     1664   1664   1        2558.5684   2555.1450   279     2559.5801   817
+    [ensemble] RunPhase1                     1664   1664   1        1879.7292   1872.5078   376     1905.4939   1
+      [ESM0001] RunPhase1                    1664   1664   1        1879.7286   1872.5059   858     1905.4937   1
+        [OCN] RunPhase1                      1300   1300   960      1850.4170   1848.3905   1023    1858.6404   364
+        [OCN-TO-MED] RunPhase1               1664   1664   960      365.9532    0.1688      405     1673.2255   18
+        [ICE] RunPhase1                      364    364    960      155.8202    154.7637    94      160.2443    0
+          cice_run_total                     364    364    960      155.4648    154.3687    94      159.8980    0
+            cice_run_import                  364    364    960      3.7565      3.5426      218     8.3892      1
+              cice_imp_halo                  364    364    1920     2.1386      1.5405      111     6.9782      0
+              cice_imp_t2u                   364    364    960      0.9242      0.5578      355     1.5026      111
+              cice_imp_atm                   364    364    960      0.0579      0.0399      331     0.0834      18
+              cice_imp_ocn                   364    364    960      0.0499      0.0419      50      0.0632      12
+            cice_run_export                  364    364    960      1.1015      0.8846      361     1.3607      194
+        [MED-TO-OCN] RunPhase1               1664   1664   960      16.7498     0.4588      256     23.2875     1023
+        [MED] med_phases_restart_write       364    364    960      31.8234     31.8123     203     33.0513     363
+          MED:(med_phases_restart_write)     364    364    960      31.7651     31.7559     203     32.9919     363
+...
+
+Where indentation depth indicates depth in the call-stack. Usually there is a header like
+********
+A warning about identifying load-imbalance.
+********
+Note that the profiling summary stats may contain identical region names
+e.g. [ATM-TO-MED] RunPhase1 is found twice in OM3.
+"""
+
+from pint import Unit
+
+from access.profiling.metrics import (
+    ProfilingMetric,
+    count,
+    pemax,
+    pemin,
+    tavg,
+    tmax,
+    tmin,
+)
+from access.profiling.parser import ProfilingParser
+
+pets = ProfilingMetric("PETs", Unit("dimensionless"), "ESMF Virtual Machine Persistent Execution Threads")
+pes = ProfilingMetric("PEs", Unit("dimensionless"), "Processing Elements")
+
+
+class ESMFSummaryProfilingParser(ProfilingParser):
+    """ESMF text summary profiling output parser."""
+
+    hierarchical: bool  # whether the call-stack hierarchy is parsed.
+
+    def __init__(self, hierarchical: bool = False):
+        """Instantiate ESMF profiling parser.
+
+        Args:
+            hierarchical (bool): Whether call-stack hierarchy is parsed.
+        """
+        super().__init__()
+
+        self.hierarchical = hierarchical
+
+        # ESMF provides the following metrics
+        self._metrics = [pets, pes, count, tavg, tmin, pemin, tmax, pemax]
+
+    def read(self, stream: str) -> dict:
+        lines = stream.strip().split("\n")
+
+        if self.hierarchical:
+            result = {}
+            stack = [(result, -1)]  # (current_dict, indent_level)
+        else:
+            result = {m: [] for m in self._metrics}
+            result["region"] = []
+
+        for line in lines:
+            # Split the line into region name and statistics
+            parts = line.split()
+            if len(parts) < (1 + len(self._metrics)):  # Need at least 1 region + the number of stat columns
+                continue
+
+            # Extract region name and statistics
+            region = " ".join(parts[:-8])
+            stats = parts[-8:]
+
+            # Validate that all statistics can be parsed correctly
+            try:
+                stats_dict = {
+                    pets: int(stats[0]),
+                    pes: int(stats[1]),
+                    count: int(stats[2]),
+                    tavg: float(stats[3]),
+                    tmin: float(stats[4]),
+                    pemin: int(stats[5]),
+                    tmax: float(stats[6]),
+                    pemax: int(stats[7]),
+                }
+            except (ValueError, IndexError):
+                # Skip lines that don't match the expected format
+                continue
+
+            if self.hierarchical:
+                # Calculate indentation level (each level is 2 spaces)
+                indent = len(line) - len(line.lstrip())
+                indent_level = indent // 2
+
+                # Pop stack until we find the parent level
+                while stack and stack[-1][1] >= indent_level:
+                    stack.pop()
+
+                # Get parent dictionary
+                parent_dict = stack[-1][0]
+
+                # Create entry for this region
+                if region not in parent_dict:
+                    parent_dict[region] = {}
+
+                # Add statistics to this region
+                parent_dict[region].update(stats_dict)
+
+                # Push this level onto stack for potential children
+                stack.append((parent_dict[region], indent_level))
+            else:
+                _update_flat_result(result, stats_dict, region)
+
+        # fewer if statements to pass ruff checks
+        if (self.hierarchical and not result) or (not self.hierarchical and len(result["region"]) == 0):
+            raise ValueError("No ESMF summary profiling data found")
+
+        return result
+
+
+def _update_flat_result(result: dict, stats_dict: dict, region: str):
+    """Helper function to update flat result.
+
+    Besides appending results, this function also checks whether the region already exists
+    and aggregates the metric values in result if possible.
+
+    Args:
+        result (dict): The flat result dictionary to update.
+        stats_dict (dict): The stats to update the result with.
+        region (str): The region to append the results to.
+
+    Raises:
+        NotImplementedError: If a stats_dict["region"] is already in result["region"],
+                             but the PETs or PEs value aren't the same.
+    """
+    # Flat structure: just use region name as key
+    try:
+        idx = result["region"].index(region)
+        # only update existing region if PETs and PEs are same
+        if (
+            result[pets][idx] == stats_dict[pets]
+            and result[pes][idx] == stats_dict[pes]
+            and stats_dict[pets] == stats_dict[pes]
+        ):
+            # new avg is weighted average using count as the weight
+            result[tavg][idx] = (result[tavg][idx] * result[count][idx] + stats_dict[tavg] * stats_dict[count]) / (
+                result[count][idx] + stats_dict[count]
+            )
+            result[count][idx] += stats_dict[count]
+            if stats_dict[tmin] < result[tmin][idx]:
+                result[tmin][idx] = stats_dict[tmin]
+                result[pemin][idx] = stats_dict[pemin]
+            if stats_dict[tmax] > result[tmax][idx]:
+                result[tmax][idx] = stats_dict[tmax]
+                result[pemax][idx] = stats_dict[pemax]
+        else:
+            raise NotImplementedError(
+                "I don't know what to do with multiple regions with same name, but different PETs/PEs."
+            )
+    except ValueError:
+        result["region"].append(region)
+        for k, v in stats_dict.items():
+            result[k].append(v)

--- a/tests/test_esmf_summary_parser.py
+++ b/tests/test_esmf_summary_parser.py
@@ -1,0 +1,263 @@
+# Copyright 2025 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from access.profiling import ESMFSummaryProfilingParser
+from access.profiling.metrics import count, pemax, pemin, tavg, tmax, tmin
+
+
+@pytest.fixture(scope="module")
+def flat_esmf_summary_parser():
+    """Fixture instantiating the ESMF summary parser where parsed results are flat."""
+    return ESMFSummaryProfilingParser()
+
+
+@pytest.fixture(scope="module")
+def hierarchical_esmf_summary_parser():
+    """Fixture instantiating the ESMF summary parser where parsed results are hierarchical."""
+    return ESMFSummaryProfilingParser(hierarchical=True)
+
+
+@pytest.fixture(scope="module")
+def flat_esmf_summary_profiling():
+    """Fixture returning a flat dict holding the parsed ESMF summary timing content."""
+    return {
+        "region": [
+            "[ESMF]",
+            "[ICE] RunPhase1",
+            "cice_run_total",
+            "cice_run_import",
+            "cice_run_export",
+            "[MED-TO-OCN] RunPhase1",
+        ],
+        count: [1, 960, 960, 960, 960, 960],
+        tavg: [
+            2558.5684,
+            155.8202,
+            155.4648,
+            3.7565,
+            1.1015,
+            16.7498,
+        ],
+        tmin: [
+            2555.1450,
+            154.7637,
+            154.3687,
+            3.5426,
+            0.8846,
+            0.4588,
+        ],
+        pemin: [279, 94, 94, 218, 361, 256],
+        tmax: [
+            2559.5801,
+            160.2443,
+            159.8980,
+            8.3892,
+            1.3607,
+            23.2875,
+        ],
+        pemax: [817, 0, 0, 1, 194, 1023],
+    }
+
+
+@pytest.fixture(scope="module")
+def hierarchical_esmf_summary_profiling():
+    """Fixture returning a hierarchical dict holding the parsed ESMF summary timing content."""
+    return {
+        "[ESMF]": {
+            count: 1,
+            tavg: 2558.5684,
+            tmin: 2555.1450,
+            pemin: 279,
+            tmax: 2559.5801,
+            pemax: 817,
+            "[ICE] RunPhase1": {
+                count: 960,
+                tavg: 155.8202,
+                tmin: 154.7637,
+                pemin: 94,
+                tmax: 160.2443,
+                pemax: 0,
+                "cice_run_total": {
+                    count: 960,
+                    tavg: 155.4648,
+                    tmin: 154.3687,
+                    pemin: 94,
+                    tmax: 159.8980,
+                    pemax: 0,
+                    "cice_run_import": {
+                        count: 960,
+                        tavg: 3.7565,
+                        tmin: 3.5426,
+                        pemin: 218,
+                        tmax: 8.3892,
+                        pemax: 1,
+                    },
+                    "cice_run_export": {
+                        count: 960,
+                        tavg: 1.1015,
+                        tmin: 0.8846,
+                        pemin: 361,
+                        tmax: 1.3607,
+                        pemax: 194,
+                    },
+                },
+            },
+            "[MED-TO-OCN] RunPhase1": {
+                count: 960,
+                tavg: 16.7498,
+                tmin: 0.4588,
+                pemin: 256,
+                tmax: 23.2875,
+                pemax: 1023,
+            },
+        }
+    }
+
+
+@pytest.fixture(scope="module")
+def esmf_log_file():
+    """Fixture returning the ESMF summary timing content."""
+    return """********
+IMPORTANT: Large deviations between Connector times on different PETs
+are typically indicators of load imbalance in the system. The following
+Connectors in this profile may indicate a load imbalance:
+     - [OCN-TO-MED] RunPhase1
+********
+
+Region                         PETs   PEs    Count    Mean (s)    Min (s)     Min PET Max (s)     Max PET
+  [ESMF]                       1664   1664   1        2558.5684   2555.1450   279     2559.5801   817    
+    [ICE] RunPhase1            364    364    960      155.8202    154.7637    94      160.2443    0      
+      cice_run_total           364    364    960      155.4648    154.3687    94      159.8980    0      
+        cice_run_import        364    364    960      3.7565      3.5426      218     8.3892      1      
+        cice_run_export        364    364    960      1.1015      0.8846      361     1.3607      194    
+    [MED-TO-OCN] RunPhase1     1664   1664   960      16.7498     0.4588      256     23.2875     1023   
+"""
+
+
+@pytest.fixture(scope="module")
+def incorrect_esmf_log_file():
+    """Fixture returning an ESMF summary timing output with missing values."""
+    return """
+  [ESMF]                      1664   1        2558.5684   2555.1450   279     2559.5801   817    
+    [ensemble] RunPhase1      1664   1664   1        1879.7292               376     1905.4939   1      
+      [ESM0001] RunPhase1     1664   1664   1.0      1879.7286   1872.5059   858     1905.4937   1      
+    """
+
+
+@pytest.fixture(scope="module")
+def duplicate_region_log_file():
+    return """
+Region                         PETs   PEs    Count    Mean (s)    Min (s)     Min PET Max (s)     Max PET
+  [ESMF]                       1664   1664   1        10.0000     9.0000      0       11.0000     1663    
+    [NEST1] region1            364    364    960      4.0000      3.0000      0       5.0000      1663    
+    [NEST1] region1            364    364    1920     6.0000      2.0000      1       6.5000      1662    
+"""
+
+
+@pytest.fixture(scope="module")
+def duplicate_region_profiling():
+    return {
+        "region": ["[ESMF]", "[NEST1] region1"],
+        count: [1, 2880],
+        tavg: [10.0, (960 * 4.0 + 1920 * 6.0) / (960 + 1920)],
+        tmin: [9.0, 2.0],
+        pemin: [0, 1],
+        tmax: [11.0, 6.5],
+        pemax: [1663, 1662],
+    }
+
+
+@pytest.fixture(scope="module")
+def duplicate_region_with_nonmatching_pes_log_file():
+    return """
+Region                         PETs   PEs    Count    Mean (s)    Min (s)     Min PET Max (s)     Max PET
+  [ESMF]                       1664   1664   1        10.0000     9.0000      0       11.0000     1663    
+    [NEST1] region1            364    364    960      4.0000      3.0000      0       5.0000      1663    
+    [NEST1] region1            728    728    1920     6.0000      2.0000      1       6.5000      1662    
+"""
+
+
+def check_nested_dict(
+    input_dict: dict,
+    correct_dict: dict,
+    metric_keys: set = None,
+    region: str = "[ESMF]",
+    depth: int = 1,
+):
+    """Helper function to check that all key-value pairs of correct_dict are in input_dict.
+
+    Args:
+        input_dict (dict): The dict to check.
+        correct_dict (dict): The correct dict used to check input_dict.
+        metric_keys (set): Expected metrics at each level of the dict (except root).
+        region (str): The region currently being checked.
+        depth (int): The depth currently being checked.
+    """
+
+    # set default metric_keys
+    if metric_keys is None:
+        metric_keys = {count, tavg, tmin, pemin, tmax, pemax}
+
+    # check that all keys in correct_dict are in input_dict
+    if input_dict.keys() < correct_dict.keys():
+        raise ValueError(f"Missing keys for {region} (depth: {depth}): {set(correct_dict.keys()) - input_dict.keys()}")
+    region_keys = set(correct_dict.keys()) - metric_keys
+
+    # first check metric values
+    for k in metric_keys:
+        assert input_dict[k] == correct_dict[k], (
+            f"Incorrect {k} value at {region} (depth: {depth}): expected {correct_dict[k]}, but got {input_dict[k]}."
+        )
+
+    # recursively check children dicts
+    for k in region_keys:
+        check_nested_dict(input_dict[k], correct_dict[k], metric_keys, k, depth + 1)
+
+
+def test_flat_esmf_profiling(flat_esmf_summary_parser, esmf_log_file, flat_esmf_summary_profiling):
+    """Test the correct parsing of ESMF timing summary information with flat structure."""
+    parsed_log = flat_esmf_summary_parser.read(esmf_log_file)
+    for idx, region in enumerate(flat_esmf_summary_profiling["region"]):
+        assert region in parsed_log["region"], f"{region} not found in ESMF parsed summary timings."
+        for metric in (tavg, tmin, pemin, tmax, pemax):
+            assert flat_esmf_summary_profiling[metric][idx] == parsed_log[metric][idx], (
+                f"Incorrect {metric.name} for region {region} (idx: {idx}). \
+Expected {flat_esmf_summary_profiling[metric][idx]}, got {parsed_log[metric][idx]}."
+            )
+
+
+def test_hierarchical_esmf_profiling(
+    hierarchical_esmf_summary_parser, esmf_log_file, hierarchical_esmf_summary_profiling
+):
+    """Test the correct parsing of ESMF timing summary information with hierarchical structure."""
+    parsed_log = hierarchical_esmf_summary_parser.read(esmf_log_file)
+    check_nested_dict(parsed_log["[ESMF]"], hierarchical_esmf_summary_profiling["[ESMF]"])
+
+
+def test_esmf_missing_values(flat_esmf_summary_parser, hierarchical_esmf_summary_parser, incorrect_esmf_log_file):
+    """Tests that row isn't picked up when values are missing."""
+    # check flat parser
+    with pytest.raises(ValueError):
+        flat_esmf_summary_parser.read(incorrect_esmf_log_file)
+    # check hierarchical parser
+    with pytest.raises(ValueError):
+        hierarchical_esmf_summary_parser.read(incorrect_esmf_log_file)
+
+
+def test_esmf_repeat_region(flat_esmf_summary_parser, duplicate_region_log_file, duplicate_region_profiling):
+    """Tests that duplicate regions are aggregated correctly."""
+    parsed_log = flat_esmf_summary_parser.read(duplicate_region_log_file)
+    for idx, region in enumerate(duplicate_region_profiling["region"]):
+        assert region in parsed_log["region"], f"{region} not found in ESMF parsed summary timings."
+        for metric in (tavg, tmin, pemin, tmax, pemax):
+            assert duplicate_region_profiling[metric][idx] == parsed_log[metric][idx], (
+                f"Incorrect {metric.name} for region {region} (idx: {idx}). \
+                    {duplicate_region_profiling[metric][idx]}, got {parsed_log[metric][idx]}."
+            )
+
+
+def test_esmf_repeat_region_nonmatching_pes(flat_esmf_summary_parser, duplicate_region_with_nonmatching_pes_log_file):
+    with pytest.raises(NotImplementedError):
+        flat_esmf_summary_parser.read(duplicate_region_with_nonmatching_pes_log_file)


### PR DESCRIPTION
This add's a parser for esmf's text summary which can be parsed "flat" or hierarchically. We probably only need flat for now, but the latter might be useful at some point.