### PR TITLE
standardize um total walltime parser

### DIFF
--- a/src/access/profiling/um_parser.py
+++ b/src/access/profiling/um_parser.py
@@ -205,6 +205,8 @@ class UMProfilingParser(ProfilingParser):
 class UMTotalRuntimeParser(ProfilingParser):
     """Parser for UM total runtime from the UM log file."""
 
+    _metrics = [tmax]
+
     def read(self, stream: str) -> float:
         """Parse UM total runtime from a string.
 
@@ -230,4 +232,4 @@ class UMTotalRuntimeParser(ProfilingParser):
         total_time = float(total_runtime_match.group("total_time"))
         logger.debug(f"Found total UM runtime: {total_time} seconds")
 
-        return total_time
+        return {"region": ["um_total_walltime"], tmax: [total_time]}

--- a/tests/test_um_parser.py
+++ b/tests/test_um_parser.py
@@ -413,9 +413,15 @@ def um_total_runtime_parser():
 
 def test_um_total_runtime_parsing(um_total_runtime_parser, um_total_runtime_raw_profiling_data):
     """Test that parsed UM total runtime data *exactly* matches the known-correct profiling data"""
-    walltime = um_total_runtime_parser.read(um_total_runtime_raw_profiling_data)
+    parsed_log = um_total_runtime_parser.read(um_total_runtime_raw_profiling_data)
 
-    assert walltime == 3944.07699399998, f"Incorrect total wallclock time. Expected 3944.07699399998, got {walltime}"
+    assert "um_total_walltime" in parsed_log["region"]
+    assert len(parsed_log["region"]) == 1, (
+        f"Incorrect number of regions. Found {len(parsed_log['region'])} instead of 1."
+    )
+    assert parsed_log[tmax][0] == 3944.07699399998, (
+        f"Incorrect total wallclock time. Expected 3944.07699399998, got {parsed_log[tmax][0]}"
+    )
 
 
 def test_um_total_runtime_parsing_missing_section(um7_raw_profiling_data, um_total_runtime_parser):


### PR DESCRIPTION
@micaeljtoliveira @manodeep 

A quick pull request that standardizes the new um total walltime parser.

* returns a dict instead of float (like the other parsers)
* defines the `_metrics` property of the parser
    * I've chosen `tmax` but feel free to suggest a different one

These changes are needed to make my `CylcRoseManager.parse_profiling_data` method work.