### PR TITLE
Extend the types of data the profiling parsers can handle

### DIFF
--- a/src/access/profiling/experiment.py
+++ b/src/access/profiling/experiment.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import xarray as xr
 
-from access.profiling.parser import ProfilingParser
+from access.profiling.parser import ProfilingParser, flatten_hierarchical
 
 logger = logging.getLogger(__name__)
 
@@ -42,22 +42,38 @@ class ProfilingLog:
     def parse(self) -> xr.Dataset:
         """Parses the log file and returns the profiling data as an xarray Dataset.
 
+        Accepts all three parser output formats (see parser.py module docstring):
+
+        - **Flat**: standard 1D Dataset over the ``region`` dimension.
+        - **Hierarchical nested dict**: automatically flattened via
+          :func:`flatten_hierarchical` before building the Dataset.
+        - **Per-PE**: produces a 2D Dataset with both ``region`` and ``pe`` dimensions.
+          Use :func:`aggregate_pe_data` on the result to compute summary statistics.
+
         Returns:
-           xr.Dataset: Parsed profiling data."""
-        path = self.filepath
-        data = self.parser.parse(path)
+           xr.Dataset: Parsed profiling data.
+        """
+        data = self.parser.parse(self.filepath)
+
+        # Flatten hierarchical (nested dict) format if needed
+        if "region" not in data:
+            data = flatten_hierarchical(data, self.parser.metrics)
+
+        has_pe = "pe" in data
+        dims = ["region", "pe"] if has_pe else ["region"]
+        coords: dict = {"region": data["region"]}
+        if has_pe:
+            coords["pe"] = data["pe"]
+
         return xr.Dataset(
             data_vars=dict(
                 zip(
                     self.parser.metrics,
-                    [
-                        xr.DataArray(data[metric], dims=["region"]).pint.quantify(metric.units)
-                        for metric in self.parser.metrics
-                    ],
+                    [xr.DataArray(data[m], dims=dims).pint.quantify(m.units) for m in self.parser.metrics],
                     strict=True,
                 )
             ),
-            coords={"region": data["region"]},
+            coords=coords,
         )
 
 

--- a/src/access/profiling/metrics.py
+++ b/src/access/profiling/metrics.py
@@ -1,7 +1,36 @@
 # Copyright 2025 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Classes and utilities to define profiling metrics."""
+"""Classes and utilities to define profiling metrics.
+
+Metrics are classified by which dimension(s) they aggregate over.
+
+Aggregation dimensions
+----------------------
+call
+    A single invocation of a profiling region. Statistics over this dimension
+    describe how timing varies across repeated calls to the same region within one run.
+pe
+    A processing element (MPI process). Statistics over this dimension describe how
+    timing varies across parallel processes for a given call (or a call-aggregated value).
+call_pe
+    Both dimensions simultaneously — global statistics across all calls and PEs.
+
+Metric naming convention
+------------------------
+New metric names encode aggregation dimension(s) as underscore-separated suffixes:
+
+    <base>_<stat>_<dimension>
+
+Examples:
+    tmin            minimum time over calls (implicit _call suffix; legacy name)
+    tavg_max_pe     maximum across PEs of the per-call average time
+    t_min_call_pe   global minimum across both calls and PEs
+
+The pre-defined constants below (tmin, tmax, tavg, …) carry an implicit _call
+dimension for backward compatibility. New metrics should always make the dimension
+suffix explicit.
+"""
 
 from pint import Unit
 
@@ -44,13 +73,13 @@ class ProfilingMetric:
         return self._name
 
 
-# Define common metrics
+# Per-call statistics (reduced over repeated invocations of the same region)
 count = ProfilingMetric("count", Unit("dimensionless"), "Number of calls to region")
-tmin = ProfilingMetric("minimum time", Unit("second"), "Minimum time spent in region")
-tmax = ProfilingMetric("maximum time", Unit("second"), "Maximum time spent in region")
-pemin = ProfilingMetric("minimum PE", Unit("dimensionless"), "Processing element where minimum time was recorded")
-pemax = ProfilingMetric("maximum PE", Unit("dimensionless"), "Processing element where maximum time was recorded")
-tavg = ProfilingMetric("average time", Unit("second"), "Average time spent in region")
-tmed = ProfilingMetric("median time", Unit("second"), "Median time spent in region")
-tstd = ProfilingMetric("time std", Unit("second"), "Standard deviation of time spent in region")
-tfrac = ProfilingMetric("time fraction", Unit("%"), "Fraction of total time spent in region")
+tmin = ProfilingMetric("minimum time", Unit("second"), "Minimum time over calls to region")
+tmax = ProfilingMetric("maximum time", Unit("second"), "Maximum time over calls to region")
+pemin = ProfilingMetric("minimum PE", Unit("dimensionless"), "Processing element where minimum call time was recorded")
+pemax = ProfilingMetric("maximum PE", Unit("dimensionless"), "Processing element where maximum call time was recorded")
+tavg = ProfilingMetric("average time", Unit("second"), "Mean time over calls to region")
+tmed = ProfilingMetric("median time", Unit("second"), "Median time over calls to region")
+tstd = ProfilingMetric("time std", Unit("second"), "Standard deviation of time over calls to region")
+tfrac = ProfilingMetric("time fraction", Unit("%"), "Fraction of total time over calls to region")

--- a/src/access/profiling/parser.py
+++ b/src/access/profiling/parser.py
@@ -1,7 +1,43 @@
 # Copyright 2025 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Classes and utilities to build profiling parsers for reading profiling data."""
+"""Classes and utilities for reading and transforming profiling data.
+
+Data formats
+------------
+Parsers return a plain dict. Three shapes are supported:
+
+Flat (standard)
+    One list per metric, all the same length as 'region':
+
+        {'region': [...], metric_a: [...], metric_b: [...]}
+
+Hierarchical (nested dict)
+    Used when regions form a call-stack tree (e.g. ESMF). String keys are child
+    region names; ProfilingMetric keys are metric values. The two key types never
+    collide, so no separator is needed:
+
+        {'[ESMF]': {tavg: 2558.6, '[ICE] RunPhase1': {tavg: 155.8, ...}}}
+
+    Use flatten_hierarchical() to convert to the flat format.
+
+Per-PE
+    Each region has one measurement per processing element (MPI process). Metric
+    values are 2D lists of shape (n_regions, n_pes); a 'pe' key holds the PE IDs:
+
+        {'region': [...], 'pe': [0, 1, ..., N-1], metric_a: [[...], [...]]}
+
+    Use aggregate_pe_data() on the resulting xarray Dataset to reduce over PEs
+    and compute load-imbalance statistics (see metrics.py for the naming convention).
+
+Utilities
+---------
+flatten_hierarchical(data, metrics)
+    Converts a hierarchical nested dict to the standard flat dict (DFS pre-order).
+aggregate_pe_data(ds)
+    Reduces a per-PE Dataset along 'pe', producing variables named
+    {var}_{stat}_pe for each input variable and statistic.
+"""
 
 import os
 from abc import ABC, abstractmethod
@@ -10,6 +46,7 @@ from typing import Any
 
 # Next import is required to register pint with xarray
 import pint_xarray  # noqa: F401
+import xarray as xr
 
 from access.profiling.metrics import ProfilingMetric
 
@@ -17,20 +54,33 @@ from access.profiling.metrics import ProfilingMetric
 class ProfilingParser(ABC):
     """Abstract parser of profiling data.
 
-    The main purpose of a parser of profiling data is to read said data from a file or directory and return it in a
-    standard format.
+    The main purpose of a parser is to read profiling data from a file and return it
+    as a dict. Three output shapes are supported (see module docstring for full details):
 
-    Once parsed, the profiling data should be stored in a dict in the following way:
+    Flat (standard)::
 
-    {
-        'region': ['region1', 'region2', ...],
-        'metric a': [val1a, val2a, ...],
-        'metric b': [val1b, val2b, ...],
-        ...
-    }
+        {
+            'region': ['region1', 'region2', ...],
+            metric_a: [val1a, val2a, ...],
+            metric_b: [val1b, val2b, ...],
+        }
 
-    The 'region' values correspond to the labels of the profile regions. Then, for each metric, there is a list of
-    values, one for each profiling region. Therefore, 'val1a', is the value for metric a of region 1.
+    Hierarchical (nested dict, no 'region' key)::
+
+        {
+            'root_region': {
+                metric_a: val,
+                'child_region': {metric_a: val, ...},
+            }
+        }
+
+    Per-PE (flat with an additional 'pe' key; metric values are 2D lists)::
+
+        {
+            'region': ['region1', 'region2', ...],
+            'pe': [0, 1, ..., N-1],
+            metric_a: [[pe0_val1, pe1_val1, ...], [pe0_val2, pe1_val2, ...]],
+        }
     """
 
     _metrics: list[ProfilingMetric]
@@ -48,13 +98,103 @@ class ProfilingParser(ABC):
             file_path (str | Path | os.PathLike): file to parse.
 
         Returns:
-            dict: profiling data.
+            dict: profiling data in one of the three formats described in the class
+                docstring (flat, hierarchical, or per-PE).
 
         Raises:
             ValueError: If no parsable text is found in file_path.
             TypeError: If file_path cannot be converted to a valid Path object.
             FileNotFoundError: If file_path doesn't exist or isn't a file.
         """
+
+
+def flatten_hierarchical(data: dict, metrics: list[ProfilingMetric]) -> dict:
+    """Converts a hierarchical (nested dict) parser output into the standard flat format.
+
+    Traverses the nested dict depth-first (pre-order: parent before children).
+    At each node, string keys are treated as child region names and ProfilingMetric
+    keys as metric values — these types never collide so no separator is needed.
+
+    Args:
+        data (dict): Nested dict as returned by a hierarchical parser. At each level,
+            string keys are child region names and ProfilingMetric keys are metric values.
+        metrics (list[ProfilingMetric]): Metrics to extract from each node.
+
+    Returns:
+        dict: Standard flat profiling dict with a 'region' key and one list per metric.
+    """
+    result: dict = {"region": []}
+    for m in metrics:
+        result[m] = []
+
+    def _visit(node: dict, name: str) -> None:
+        result["region"].append(name)
+        for m in metrics:
+            result[m].append(node.get(m))
+        for key, value in node.items():
+            if isinstance(key, str):  # child region — ProfilingMetric keys are not str
+                _visit(value, key)
+
+    for region_name, region_data in data.items():
+        _visit(region_data, region_name)
+
+    return result
+
+
+def aggregate_pe_data(ds: xr.Dataset) -> xr.Dataset:
+    """Aggregates a per-PE profiling Dataset into summary statistics over the pe dimension.
+
+    For each data variable, computes the following reductions over the 'pe' dimension
+    and returns them as new string-named variables following the {var}_{stat}_pe
+    convention defined in metrics.py:
+
+    ========================  =============================================
+    Variable                  Description
+    ========================  =============================================
+    ``{var}_min_pe``          minimum across PEs
+    ``{var}_max_pe``          maximum across PEs
+    ``{var}_mean_pe``         mean across PEs
+    ``{var}_median_pe``       median across PEs
+    ``{var}_std_pe``          standard deviation across PEs
+    ``{var}_total_pe``        sum across PEs (total work done by all PEs)
+    ``{var}_argmin_pe``       PE index of the minimum value (dimensionless)
+    ``{var}_argmax_pe``       PE index of the maximum value (dimensionless)
+    ``{var}_imbalance_pe``    (max - min) / mean; 0 = perfectly balanced
+    ========================  =============================================
+
+    Args:
+        ds (xr.Dataset): Dataset with a 'pe' dimension, as returned by
+            ProfilingLog.parse() for per-PE parser output.
+
+    Returns:
+        xr.Dataset: New Dataset with 'pe' reduced, containing the derived variables
+            described above. All non-pe coordinates are preserved.
+
+    Raises:
+        ValueError: If ds does not have a 'pe' dimension.
+    """
+    if "pe" not in ds.dims:
+        raise ValueError("Dataset does not have a 'pe' dimension.")
+
+    result_vars = {}
+    for var in ds.data_vars:
+        da = ds[var]
+        base = str(var).replace(" ", "_")
+        vmin = da.min("pe")
+        vmax = da.max("pe")
+        vmean = da.mean("pe")
+        result_vars[f"{base}_min_pe"] = vmin
+        result_vars[f"{base}_max_pe"] = vmax
+        result_vars[f"{base}_mean_pe"] = vmean
+        result_vars[f"{base}_median_pe"] = da.median("pe")
+        result_vars[f"{base}_std_pe"] = da.std("pe")
+        result_vars[f"{base}_total_pe"] = da.sum("pe")
+        result_vars[f"{base}_argmin_pe"] = da.argmin("pe")
+        result_vars[f"{base}_argmax_pe"] = da.argmax("pe")
+        result_vars[f"{base}_imbalance_pe"] = (vmax - vmin) / vmean
+
+    coords = {k: v for k, v in ds.coords.items() if k != "pe"}
+    return xr.Dataset(result_vars, coords=coords)
 
 
 def _convert_from_string(value: str) -> Any:

--- a/src/access/profiling/parser.py
+++ b/src/access/profiling/parser.py
@@ -191,7 +191,7 @@ def aggregate_pe_data(ds: xr.Dataset) -> xr.Dataset:
         result_vars[f"{base}_total_pe"] = da.sum("pe")
         result_vars[f"{base}_argmin_pe"] = da.argmin("pe")
         result_vars[f"{base}_argmax_pe"] = da.argmax("pe")
-        result_vars[f"{base}_imbalance_pe"] = (vmax - vmin) / vmean
+        result_vars[f"{base}_imbalance_pe"] = xr.where(vmean != 0, (vmax - vmin) / vmean, 0)
 
     coords = {k: v for k, v in ds.coords.items() if k != "pe"}
     return xr.Dataset(result_vars, coords=coords)

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -44,6 +44,50 @@ def test_profiling_log():
     mock_parser.parse.assert_called_once_with(mock_path)
 
 
+def test_profiling_log_hierarchical():
+    """Test ProfilingLog.parse() with hierarchical (nested dict) parser output."""
+    mock_parser = mock.MagicMock(autospec=True)
+    mock_parser.metrics = [tavg, tmax]
+    # Nested dict: no 'region' key — string keys are children, metric keys are values
+    mock_parser.parse.return_value = {
+        "Root": {
+            tavg: 10.0,
+            tmax: 12.0,
+            "Child1": {tavg: 4.0, tmax: 5.0},
+            "Child2": {tavg: 6.0, tmax: 7.0},
+        }
+    }
+
+    mock_path = mock.MagicMock()
+    dataset = ProfilingLog(filepath=mock_path, parser=mock_parser).parse()
+
+    # DFS pre-order: Root, Child1, Child2
+    assert list(dataset["region"].values) == ["Root", "Child1", "Child2"]
+    assert list(dataset[tavg].values) == [10.0, 4.0, 6.0]
+    assert list(dataset[tmax].values) == [12.0, 5.0, 7.0]
+    assert set(dataset.dims) == {"region"}
+
+
+def test_profiling_log_with_pe():
+    """Test ProfilingLog.parse() with per-PE parser output."""
+    mock_parser = mock.MagicMock(autospec=True)
+    mock_parser.metrics = [tavg]
+    mock_parser.parse.return_value = {
+        "region": ["Region 1", "Region 2"],
+        "pe": [0, 1, 2],
+        tavg: [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
+    }
+
+    mock_path = mock.MagicMock()
+    dataset = ProfilingLog(filepath=mock_path, parser=mock_parser).parse()
+
+    assert set(dataset.dims) == {"region", "pe"}
+    assert dataset[tavg].shape == (2, 3)
+    assert list(dataset.coords["pe"].values) == [0, 1, 2]
+    assert list(dataset[tavg].isel(region=0).pint.dequantify().values) == [1.0, 2.0, 3.0]
+    assert list(dataset[tavg].isel(region=1).pint.dequantify().values) == [4.0, 5.0, 6.0]
+
+
 def test_profiling_experiment():
     """Test the ProfilingExperiment class constructor, status and directory context manager."""
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -5,9 +5,10 @@ import os
 from pathlib import Path
 
 import pytest
+import xarray as xr
 
 from access.profiling.metrics import count, tmax, tmin
-from access.profiling.parser import ProfilingParser, _convert_from_string, _read_text_file
+from access.profiling.parser import ProfilingParser, _convert_from_string, _read_text_file, aggregate_pe_data
 
 
 class MockProfilingParser(ProfilingParser):
@@ -84,3 +85,60 @@ def test_read_text_file(tmp_path):
         _read_text_file(bytes_file)
     with pytest.raises(FileNotFoundError):
         _read_text_file(tmp_path / "nonexistent.log")
+
+
+@pytest.fixture(scope="module")
+def per_pe_dataset():
+    """Dataset with a 'pe' dimension for testing aggregate_pe_data."""
+    # 2 regions, 4 PEs; tmin values deliberately unequal to test imbalance
+    return xr.Dataset(
+        {
+            tmin: xr.DataArray([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]], dims=["region", "pe"]),
+            tmax: xr.DataArray([[2.0, 4.0, 6.0, 8.0], [1.0, 3.0, 5.0, 7.0]], dims=["region", "pe"]),
+        },
+        coords={"region": ["Region 1", "Region 2"], "pe": [0, 1, 2, 3]},
+    )
+
+
+def test_aggregate_pe_data_values(per_pe_dataset):
+    """Tests that all nine derived variables are computed correctly."""
+    result = aggregate_pe_data(per_pe_dataset)
+
+    base = str(tmin).replace(" ", "_")
+
+    # Region 1 tmin values: [1, 2, 3, 4]
+    assert result[f"{base}_min_pe"].sel(region="Region 1").item() == pytest.approx(1.0)
+    assert result[f"{base}_max_pe"].sel(region="Region 1").item() == pytest.approx(4.0)
+    assert result[f"{base}_mean_pe"].sel(region="Region 1").item() == pytest.approx(2.5)
+    assert result[f"{base}_median_pe"].sel(region="Region 1").item() == pytest.approx(2.5)
+    assert result[f"{base}_std_pe"].sel(region="Region 1").item() == pytest.approx(
+        pytest.approx((sum((x - 2.5) ** 2 for x in [1, 2, 3, 4]) / 4) ** 0.5, rel=1e-5)
+    )
+    assert result[f"{base}_total_pe"].sel(region="Region 1").item() == pytest.approx(10.0)
+    assert result[f"{base}_argmin_pe"].sel(region="Region 1").item() == 0  # PE 0 has min
+    assert result[f"{base}_argmax_pe"].sel(region="Region 1").item() == 3  # PE 3 has max
+    # imbalance = (4 - 1) / 2.5 = 1.2
+    assert result[f"{base}_imbalance_pe"].sel(region="Region 1").item() == pytest.approx(1.2)
+
+    # 'pe' dimension should be gone; 'region' coordinate preserved
+    assert "pe" not in result.dims
+    assert "region" in result.coords
+
+
+def test_aggregate_pe_data_no_pe_dim():
+    """Tests that ValueError is raised when the dataset has no 'pe' dimension."""
+    ds = xr.Dataset({tmin: xr.DataArray([1.0, 2.0], dims=["region"])}, coords={"region": ["r1", "r2"]})
+    with pytest.raises(ValueError, match="'pe' dimension"):
+        aggregate_pe_data(ds)
+
+
+def test_aggregate_pe_data_perfect_balance():
+    """Tests that imbalance is 0 when all PEs have equal values."""
+    ds = xr.Dataset(
+        {tmin: xr.DataArray([[5.0, 5.0, 5.0], [3.0, 3.0, 3.0]], dims=["region", "pe"])},
+        coords={"region": ["r1", "r2"], "pe": [0, 1, 2]},
+    )
+    result = aggregate_pe_data(ds)
+    base = str(tmin).replace(" ", "_")
+    assert result[f"{base}_imbalance_pe"].sel(region="r1").item() == pytest.approx(0.0)
+    assert result[f"{base}_imbalance_pe"].sel(region="r2").item() == pytest.approx(0.0)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -105,15 +105,14 @@ def test_aggregate_pe_data_values(per_pe_dataset):
     result = aggregate_pe_data(per_pe_dataset)
 
     base = str(tmin).replace(" ", "_")
+    expected_std = (sum((x - 2.5) ** 2 for x in [1, 2, 3, 4]) / 4) ** 0.5
 
     # Region 1 tmin values: [1, 2, 3, 4]
     assert result[f"{base}_min_pe"].sel(region="Region 1").item() == pytest.approx(1.0)
     assert result[f"{base}_max_pe"].sel(region="Region 1").item() == pytest.approx(4.0)
     assert result[f"{base}_mean_pe"].sel(region="Region 1").item() == pytest.approx(2.5)
     assert result[f"{base}_median_pe"].sel(region="Region 1").item() == pytest.approx(2.5)
-    assert result[f"{base}_std_pe"].sel(region="Region 1").item() == pytest.approx(
-        pytest.approx((sum((x - 2.5) ** 2 for x in [1, 2, 3, 4]) / 4) ** 0.5, rel=1e-5)
-    )
+    assert result[f"{base}_std_pe"].sel(region="Region 1").item() == pytest.approx(expected_std, rel=1e-5)
     assert result[f"{base}_total_pe"].sel(region="Region 1").item() == pytest.approx(10.0)
     assert result[f"{base}_argmin_pe"].sel(region="Region 1").item() == 0  # PE 0 has min
     assert result[f"{base}_argmax_pe"].sel(region="Region 1").item() == 3  # PE 3 has max


### PR DESCRIPTION
- now hierarchical data is properly handled
- data per processing element (PE) is also taken into account Several changes to make this work:
- new metrics are introduced and the meaning of existing metrics is clarified
- added function to aggregate data over PEs
- added function to convert from hierarchical to flat

This PR was prepared with the help of Claude Opus 4.6.